### PR TITLE
`roadCost` Fix

### DIFF
--- a/src/lib/CostMatrixes/index.ts
+++ b/src/lib/CostMatrixes/index.ts
@@ -36,7 +36,7 @@ export const mutateCostMatrix = (cm: CostMatrix, room: string, opts: CostMatrixO
         }
       }
       if (opts.roadCost) {
-        if (s instanceof StructureRoad && cm.get(s.pos.x, s.pos.y) !== 255) {
+        if (s instanceof StructureRoad && cm.get(s.pos.x, s.pos.y) == 0) {
           cm.set(s.pos.x, s.pos.y, opts.roadCost);
         }
       }

--- a/src/lib/CostMatrixes/index.ts
+++ b/src/lib/CostMatrixes/index.ts
@@ -36,7 +36,7 @@ export const mutateCostMatrix = (cm: CostMatrix, room: string, opts: CostMatrixO
         }
       }
       if (opts.roadCost) {
-        if (s instanceof StructureRoad && cm.get(s.pos.x, s.pos.y) == 0) {
+        if (s instanceof StructureRoad && cm.get(s.pos.x, s.pos.y) === 0) {
           cm.set(s.pos.x, s.pos.y, opts.roadCost);
         }
       }


### PR DESCRIPTION
- Makes `roadCost` not override provided values, better matching default terrain activity.