### PR TITLE
Make `generatePath` Standalone

### DIFF
--- a/src/lib/Movement/generatePath.ts
+++ b/src/lib/Movement/generatePath.ts
@@ -3,20 +3,13 @@ import { MoveTarget } from '../';
 import { mutateCostMatrix } from '../CostMatrixes';
 import { findRoute } from '../WorldMap/findRoute';
 
-export interface GeneratePathOpts extends PathFinderOpts {
-  avoidCreeps?: boolean;
-  avoidObstacleStructures?: boolean;
-  roadCost?: number;
-  maxOpsPerRoom?: number;
-}
-
 /**
  * Generates a path with PathFinder
  */
 export function generatePath(
   origin: RoomPosition,
   targets: MoveTarget[],
-  opts: GeneratePathOpts
+  opts: MoveToOpts
 ): RoomPosition[] | undefined {
   // Generate full opts object
   const actualOpts = {

--- a/src/lib/Movement/generatePath.ts
+++ b/src/lib/Movement/generatePath.ts
@@ -4,7 +4,7 @@ import { mutateCostMatrix } from '../CostMatrixes';
 import { findRoute } from '../WorldMap/findRoute';
 
 /**
- * Generates a path with PathFinder
+ * Generates a path with PathFinder.
  */
 export function generatePath(
   origin: RoomPosition,
@@ -19,7 +19,7 @@ export function generatePath(
   // check if we need a route to limit search space
   const exits = Object.values(Game.map.describeExits(origin.roomName));
   let rooms: string[] | undefined = undefined;
-  if (!targets.some(({ pos }) => pos.roomName === origin.roomName || exits.includes(pos.roomName))) {
+  if (!targets.some(({ pos }) => pos.roomName === origin.roomName)) {
     // if there are multiple rooms in `targets`, pick the cheapest route
     const targetRooms = targets.reduce(
       (rooms, { pos }) => (rooms.includes(pos.roomName) ? rooms : [pos.roomName, ...rooms]),

--- a/src/lib/Movement/generatePath.ts
+++ b/src/lib/Movement/generatePath.ts
@@ -1,5 +1,5 @@
 import { config } from 'config';
-import { MoveTarget } from '../';
+import { MoveOpts, MoveTarget } from '../';
 import { mutateCostMatrix } from '../CostMatrixes';
 import { findRoute } from '../WorldMap/findRoute';
 
@@ -9,7 +9,7 @@ import { findRoute } from '../WorldMap/findRoute';
 export function generatePath(
   origin: RoomPosition,
   targets: MoveTarget[],
-  opts: MoveToOpts
+  opts: MoveOpts
 ): RoomPosition[] | undefined {
   // Generate full opts object
   const actualOpts = {

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -90,6 +90,7 @@ export interface MoveOpts extends PathFinderOpts {
 
 export * from './CachingStrategies';
 export * from './Movement/cachedPaths';
+export * from './Movement/generatePath';
 export * from './Movement/moveByPath';
 export * from './Movement/moveTo';
 export * from './Movement/pull';


### PR DESCRIPTION
- Modified `generatePath` `opts` to pull the defaults within itself, allowing for normal usage from outside of cartographer.
- Made `generatePath` find a route if the target was not in the origin room, to correctly inflate `maxOps`.