### PR TITLE
feat: calculate plain and swamp costs

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -3,10 +3,5 @@
     "editor.formatOnSave": true,
     "editor.codeActionsOnSave": {
         "source.organizeImports": true
-    },
-    "cSpell.words": [
-        "ALKALIDE",
-        "KEANIUM",
-        "ZYNTHIUM"
-    ]
+    }
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -3,5 +3,10 @@
     "editor.formatOnSave": true,
     "editor.codeActionsOnSave": {
         "source.organizeImports": true
-    }
+    },
+    "cSpell.words": [
+        "ALKALIDE",
+        "KEANIUM",
+        "ZYNTHIUM"
+    ]
 }

--- a/src/lib/Movement/generatePath.ts
+++ b/src/lib/Movement/generatePath.ts
@@ -8,10 +8,16 @@ import { findRoute } from '../WorldMap/findRoute';
  */
 export function generatePath(origin: RoomPosition, targets: MoveTarget[], opts?: MoveOpts): RoomPosition[] | undefined {
   // Generate full opts object
-  const actualOpts = {
+  let actualOpts = {
     ...config.DEFAULT_MOVE_OPTS,
     ...opts
   };
+
+  // Dynamic choose weight for roads, plains and swamps depending on body.
+  if (opts?.creepMovementInfo) {
+    actualOpts = { ...actualOpts, ...defaultTerrainCosts(opts.creepMovementInfo) };
+  }
+
   // check if we need a route to limit search space
   const exits = Object.values(Game.map.describeExits(origin.roomName));
   let rooms: string[] | undefined = undefined;
@@ -44,4 +50,80 @@ export function generatePath(origin: RoomPosition, targets: MoveTarget[], opts?:
   if (!result.path.length || result.incomplete) return undefined;
 
   return result.path;
+}
+
+function defaultTerrainCosts(
+  creepInfo: Required<MoveOpts>['creepMovementInfo']
+): Required<Pick<MoveOpts, 'roadCost' | 'plainCost' | 'swampCost'>> {
+  const result = {
+    roadCost: config.DEFAULT_MOVE_OPTS.roadCost || 1,
+    plainCost: config.DEFAULT_MOVE_OPTS.plainCost || 2,
+    swampCost: config.DEFAULT_MOVE_OPTS.swampCost || 10
+  };
+
+  let totalCarry = creepInfo.usedCapacity;
+
+  let moveParts = 0;
+  let usedCarryParts = 0;
+  let otherBodyParts = 0;
+
+  // Iterating right to left because carry parts are filled in that order.
+  for (let i = creepInfo.body.length - 1; i >= 0; i--) {
+    const bodyPart: BodyPartDefinition = creepInfo.body[i];
+    if (bodyPart.type !== MOVE && bodyPart.type !== CARRY) {
+      otherBodyParts++;
+    } else if (bodyPart.hits <= 0) {
+      continue;
+    } else if (bodyPart.type === MOVE) {
+      let boost = 1;
+      if (bodyPart.boost) {
+        boost = BOOSTS[MOVE][bodyPart.boost].fatigue;
+      }
+      moveParts += 1 * boost;
+    } else if (totalCarry > 0 && bodyPart.type === CARRY) {
+      let boost = 1;
+      if (bodyPart.boost) {
+        boost = BOOSTS[CARRY][bodyPart.boost].capacity;
+      }
+      // We count carry parts used by removing the capacity used by them from the total that the creep is carrying.
+      // When total is empty, resting carry parts doesn't generate fatigue (even if they have no hits).
+      totalCarry -= CARRY_CAPACITY * boost;
+      usedCarryParts++;
+    }
+  }
+
+  // If no move parts it can't move, skip and apply defaults to speed this up.
+  if (moveParts > 0) {
+    const fatigueFactor = usedCarryParts + otherBodyParts;
+    const recoverFactor = moveParts * 2;
+
+    // In case cost is 0 (only move parts), all terrains will cost 1.
+    // Hardcoding 0.1 as minimum cost to obtain this result.
+    const cost = Math.max(fatigueFactor / recoverFactor, 0.1);
+
+    // Number of ticks that it takes move over each terrain.
+    // Having this as a separated function could be interesting for obtaining how many ticks
+    // it will take a creep to walk over a route with determined terrains.
+    const roadCost = Math.ceil(cost);
+    const plainCost = Math.ceil(cost * 2);
+    const swampCost = Math.ceil(cost * 10);
+
+    // Greatest common divisor.
+    // https://github.com/30-seconds/30-seconds-of-code/blob/master/snippets/gcd.md
+    const gcd = (...arr: number[]) => {
+      const _gcd = (x: number, y: number): number => (!y ? x : gcd(y, x % y));
+      return [...arr].reduce((a, b) => _gcd(a, b));
+    };
+
+    // Calculate the greatest common divisor so we can reduce the costs to the smallest numbers possible.
+    const norm = gcd(roadCost, plainCost, swampCost);
+
+    // Normalize and set the default costs. This costs are going to be always under the 255 limit.
+    // Worst scenario is with 49 not move body parts and only 1 move part. This means a cost of 24.5,
+    // implying 25 / 49 / 245 costs for each terrain.
+    result.roadCost = roadCost / norm;
+    result.plainCost = plainCost / norm;
+    result.swampCost = swampCost / norm;
+  }
+  return result;
 }

--- a/src/lib/Movement/moveTo.ts
+++ b/src/lib/Movement/moveTo.ts
@@ -92,12 +92,14 @@ export const moveTo = (
     clearCachedPath(creep, cache);
   }
 
-  // Dynamic choose weight for roads, plains and swamps depending on body.
   // Skip if power creep or any costs has been manually set.
-  if (DEBUG) logCpu('getting default plain and swamp costs');
+  if (DEBUG) logCpu('adding creep info for calculate default road, plain and swamp costs');
   const manuallyDefinedCosts = [opts?.roadCost, opts?.plainCost, opts?.swampCost].some(cost => cost !== undefined);
   if ('body' in creep && !manuallyDefinedCosts) {
-    actualOpts = { ...actualOpts, ...defaultTerrainCosts(creep) };
+    actualOpts = {
+      ...actualOpts,
+      creepMovementInfo: { usedCapacity: creep.store.getUsedCapacity(), body: creep.body }
+    };
   }
 
   if (DEBUG) logCpu('checking opts');
@@ -204,77 +206,3 @@ export const moveTo = (
 
   return result;
 };
-
-function defaultTerrainCosts(creep: Creep): Required<Pick<MoveOpts, 'roadCost' | 'plainCost' | 'swampCost'>> {
-  const result = {
-    roadCost: config.DEFAULT_MOVE_OPTS.roadCost || 1,
-    plainCost: config.DEFAULT_MOVE_OPTS.plainCost || 2,
-    swampCost: config.DEFAULT_MOVE_OPTS.swampCost || 10
-  };
-
-  let totalCarry = creep.store.getUsedCapacity();
-
-  let moveParts = 0;
-  let usedCarryParts = 0;
-  let otherBodyParts = 0;
-
-  // Iterating right to left because carry parts are filled in that order.
-  for (let i = creep.body.length - 1; i >= 0; i--) {
-    const bodyPart: BodyPartDefinition = creep.body[i];
-    if (bodyPart.type !== MOVE && bodyPart.type !== CARRY) {
-      otherBodyParts++;
-    } else if (bodyPart.hits <= 0) {
-      continue;
-    } else if (bodyPart.type === MOVE) {
-      let boost = 1;
-      if (bodyPart.boost) {
-        boost = BOOSTS[MOVE][bodyPart.boost].fatigue;
-      }
-      moveParts += 1 * boost;
-    } else if (totalCarry > 0 && bodyPart.type === CARRY) {
-      let boost = 1;
-      if (bodyPart.boost) {
-        boost = BOOSTS[CARRY][bodyPart.boost].capacity;
-      }
-      // We count carry parts used by removing the capacity used by them from the total that the creep is carrying.
-      // When total is empty, resting carry parts doesn't generate fatigue (even if they have no hits).
-      totalCarry -= CARRY_CAPACITY * boost;
-      usedCarryParts++;
-    }
-  }
-
-  // If no move parts it can't move, skip and apply defaults to speed this up.
-  if (moveParts > 0) {
-    const fatigueFactor = usedCarryParts + otherBodyParts;
-    const recoverFactor = moveParts * 2;
-
-    // In case cost is 0 (only move parts), all terrains will cost 1.
-    // Hardcoding 0.1 as minimum cost to obtain this result.
-    const cost = Math.max(fatigueFactor / recoverFactor, 0.1);
-
-    // Number of ticks that it takes move over each terrain.
-    // Having this as a separated function could be interesting for obtaining how many ticks
-    // it will take a creep to walk over a route with determined terrains.
-    const roadCost = Math.ceil(cost);
-    const plainCost = Math.ceil(cost * 2);
-    const swampCost = Math.ceil(cost * 10);
-
-    // Greatest common divisor.
-    // https://github.com/30-seconds/30-seconds-of-code/blob/master/snippets/gcd.md
-    const gcd = (...arr: number[]) => {
-      const _gcd = (x: number, y: number): number => (!y ? x : gcd(y, x % y));
-      return [...arr].reduce((a, b) => _gcd(a, b));
-    };
-
-    // Calculate the greatest common divisor so we can reduce the costs to the smallest numbers possible.
-    const norm = gcd(roadCost, plainCost, swampCost);
-
-    // Normalize and set the default costs. This costs are going to be always under the 255 limit.
-    // Worst scenario is with 49 not move body parts and only 1 move part. This means a cost of 24.5,
-    // implying 25 / 49 / 245 costs for each terrain.
-    result.roadCost = roadCost / norm;
-    result.plainCost = plainCost / norm;
-    result.swampCost = swampCost / norm;
-  }
-  return result;
-}

--- a/src/lib/Movement/moveTo.ts
+++ b/src/lib/Movement/moveTo.ts
@@ -97,10 +97,31 @@ export const moveTo = (
   if (DEBUG) logCpu('getting default plain and swamp costs');
   const manuallyDefinedCosts = opts?.roadCost || opts?.plainCost || opts?.swampCost;
   if ('body' in creep && !manuallyDefinedCosts) {
-    const moveParts = creep.body.filter(b => b.type === MOVE).length;
+    const moveBoostsTiers = {
+      [RESOURCE_ZYNTHIUM_OXIDE]: 1,
+      [RESOURCE_ZYNTHIUM_ALKALIDE]: 2,
+      [RESOURCE_CATALYZED_ZYNTHIUM_ALKALIDE]: 3
+    };
+    const carryBoostsTiers = {
+      [RESOURCE_KEANIUM_OXIDE]: 1,
+      [RESOURCE_KEANIUM_ALKALIDE]: 2,
+      [RESOURCE_CATALYZED_KEANIUM_ALKALIDE]: 3
+    };
+    let moveParts = 0;
+    let carryParts = 0;
+    for (const bodyPart of creep.body) {
+      if (bodyPart.type === MOVE && bodyPart.hits > 0) {
+        moveParts += 1;
+        if (bodyPart.boost && bodyPart.boost in moveBoostsTiers) {
+          moveParts += moveBoostsTiers[bodyPart.boost];
+        }
+      } else if (bodyPart.type === CARRY && bodyPart.hits > 0) {
+        carryParts += 1;
+      }
+    }
+
     // If no move parts it can't move, skip and apply defaults to speed this up.
     if (moveParts > 0) {
-      const carryParts = creep.body.filter(b => b.type === CARRY).length;
       const otherBodyParts = creep.body.length - moveParts - carryParts;
       const usedCarryParts = carryParts - Math.floor(creep.store.getFreeCapacity() / 50);
 

--- a/src/lib/Movement/moveTo.ts
+++ b/src/lib/Movement/moveTo.ts
@@ -130,7 +130,7 @@ export const moveTo = (
       // implying 25 / 49 / 245 costs for each terrain.
       actualOpts.roadCost ??= roadCost / norm;
       actualOpts.plainCost ??= plainCost / norm;
-      actualOpts.swampCost ??= plainCost / norm;
+      actualOpts.swampCost ??= swampCost / norm;
     }
   }
 

--- a/src/lib/Movement/moveTo.ts
+++ b/src/lib/Movement/moveTo.ts
@@ -95,72 +95,9 @@ export const moveTo = (
   // Dynamic choose weight for roads, plains and swamps depending on body.
   // Skip if power creep or any costs has been manually set.
   if (DEBUG) logCpu('getting default plain and swamp costs');
-  const manuallyDefinedCosts = opts?.roadCost || opts?.plainCost || opts?.swampCost;
+  const manuallyDefinedCosts = [opts?.roadCost, opts?.plainCost, opts?.swampCost].some(cost => cost !== undefined);
   if ('body' in creep && !manuallyDefinedCosts) {
-    let totalCarry = creep.store.getUsedCapacity();
-
-    let moveParts = 0;
-    let usedCarryParts = 0;
-    let otherBodyParts = 0;
-
-    // Iterating right to left because carry parts are filled in that order.
-    for (let i = creep.body.length - 1; i >= 0; i--) {
-      const bodyPart: BodyPartDefinition = creep.body[i];
-      if (bodyPart.type !== MOVE && bodyPart.type !== CARRY) {
-        otherBodyParts++;
-      } else if (bodyPart.hits <= 0) {
-        continue;
-      } else if (bodyPart.type === MOVE) {
-        let boost = 1;
-        if (bodyPart.boost) {
-          boost = BOOSTS[MOVE][bodyPart.boost].fatigue;
-        }
-        moveParts += 1 * boost;
-      } else if (totalCarry > 0 && bodyPart.type === CARRY) {
-        let boost = 1;
-        if (bodyPart.boost) {
-          boost = BOOSTS[CARRY][bodyPart.boost].capacity;
-        }
-        // We count carry parts used by removing the capacity used by them from the total that the creep is carrying.
-        // When total is empty, resting carry parts doesn't generate fatigue (even if they have no hits).
-        totalCarry -= CARRY_CAPACITY * boost;
-        usedCarryParts++;
-      }
-    }
-
-    // If no move parts it can't move, skip and apply defaults to speed this up.
-    if (moveParts > 0) {
-      const fatigueFactor = usedCarryParts + otherBodyParts;
-      const recoverFactor = moveParts * 2;
-
-      // In case cost is 0 (only move parts), all terrains will cost 1.
-      // Hardcoding 0.1 as minimum cost to obtain this result.
-      const cost = Math.max(fatigueFactor / recoverFactor, 0.1);
-
-      // Number of ticks that it takes move over each terrain.
-      // Having this as a separated function could be interesting for obtaining how many ticks
-      // it will take a creep to walk over a route with determined terrains.
-      const roadCost = Math.ceil(cost);
-      const plainCost = Math.ceil(cost * 2);
-      const swampCost = Math.ceil(cost * 10);
-
-      // Greatest common divisor.
-      // https://github.com/30-seconds/30-seconds-of-code/blob/master/snippets/gcd.md
-      const gcd = (...arr: number[]) => {
-        const _gcd = (x: number, y: number): number => (!y ? x : gcd(y, x % y));
-        return [...arr].reduce((a, b) => _gcd(a, b));
-      };
-
-      // Calculate the greatest common divisor so we can reduce the costs to the smallest numbers possible.
-      const norm = gcd(roadCost, plainCost, swampCost);
-
-      // Normalize and set the default costs. This costs are going to be always under the 255 limit.
-      // Worst scenario is with 49 not move body parts and only 1 move part. This means a cost of 24.5,
-      // implying 25 / 49 / 245 costs for each terrain.
-      actualOpts.roadCost ??= roadCost / norm;
-      actualOpts.plainCost ??= plainCost / norm;
-      actualOpts.swampCost ??= swampCost / norm;
-    }
+    actualOpts = { ...actualOpts, ...defaultTerrainCosts(creep) };
   }
 
   if (DEBUG) logCpu('checking opts');
@@ -267,3 +204,77 @@ export const moveTo = (
 
   return result;
 };
+
+function defaultTerrainCosts(creep: Creep): Required<Pick<MoveOpts, 'roadCost' | 'plainCost' | 'swampCost'>> {
+  const result = {
+    roadCost: config.DEFAULT_MOVE_OPTS.roadCost || 1,
+    plainCost: config.DEFAULT_MOVE_OPTS.plainCost || 2,
+    swampCost: config.DEFAULT_MOVE_OPTS.swampCost || 10
+  };
+
+  let totalCarry = creep.store.getUsedCapacity();
+
+  let moveParts = 0;
+  let usedCarryParts = 0;
+  let otherBodyParts = 0;
+
+  // Iterating right to left because carry parts are filled in that order.
+  for (let i = creep.body.length - 1; i >= 0; i--) {
+    const bodyPart: BodyPartDefinition = creep.body[i];
+    if (bodyPart.type !== MOVE && bodyPart.type !== CARRY) {
+      otherBodyParts++;
+    } else if (bodyPart.hits <= 0) {
+      continue;
+    } else if (bodyPart.type === MOVE) {
+      let boost = 1;
+      if (bodyPart.boost) {
+        boost = BOOSTS[MOVE][bodyPart.boost].fatigue;
+      }
+      moveParts += 1 * boost;
+    } else if (totalCarry > 0 && bodyPart.type === CARRY) {
+      let boost = 1;
+      if (bodyPart.boost) {
+        boost = BOOSTS[CARRY][bodyPart.boost].capacity;
+      }
+      // We count carry parts used by removing the capacity used by them from the total that the creep is carrying.
+      // When total is empty, resting carry parts doesn't generate fatigue (even if they have no hits).
+      totalCarry -= CARRY_CAPACITY * boost;
+      usedCarryParts++;
+    }
+  }
+
+  // If no move parts it can't move, skip and apply defaults to speed this up.
+  if (moveParts > 0) {
+    const fatigueFactor = usedCarryParts + otherBodyParts;
+    const recoverFactor = moveParts * 2;
+
+    // In case cost is 0 (only move parts), all terrains will cost 1.
+    // Hardcoding 0.1 as minimum cost to obtain this result.
+    const cost = Math.max(fatigueFactor / recoverFactor, 0.1);
+
+    // Number of ticks that it takes move over each terrain.
+    // Having this as a separated function could be interesting for obtaining how many ticks
+    // it will take a creep to walk over a route with determined terrains.
+    const roadCost = Math.ceil(cost);
+    const plainCost = Math.ceil(cost * 2);
+    const swampCost = Math.ceil(cost * 10);
+
+    // Greatest common divisor.
+    // https://github.com/30-seconds/30-seconds-of-code/blob/master/snippets/gcd.md
+    const gcd = (...arr: number[]) => {
+      const _gcd = (x: number, y: number): number => (!y ? x : gcd(y, x % y));
+      return [...arr].reduce((a, b) => _gcd(a, b));
+    };
+
+    // Calculate the greatest common divisor so we can reduce the costs to the smallest numbers possible.
+    const norm = gcd(roadCost, plainCost, swampCost);
+
+    // Normalize and set the default costs. This costs are going to be always under the 255 limit.
+    // Worst scenario is with 49 not move body parts and only 1 move part. This means a cost of 24.5,
+    // implying 25 / 49 / 245 costs for each terrain.
+    result.roadCost = roadCost / norm;
+    result.plainCost = plainCost / norm;
+    result.swampCost = swampCost / norm;
+  }
+  return result;
+}

--- a/src/lib/Movement/moveTo.ts
+++ b/src/lib/Movement/moveTo.ts
@@ -107,7 +107,8 @@ export const moveTo = (
       const fatigueFactor = usedCarryParts + otherBodyParts;
       const recoverFactor = moveParts * 2;
 
-      const cost = Math.max(fatigueFactor / recoverFactor, 1);
+      // In case cost is 0 (only move parts), all terrains will cost 1.
+      const cost = Math.max(fatigueFactor / recoverFactor, 0.1);
 
       // Number of ticks that it takes move over each terrain.
       const roadCost = Math.ceil(cost);

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -80,6 +80,10 @@ export interface MoveOpts extends PathFinderOpts {
    * return `undefined`.
    */
   routeCallback?: (roomName: string, fromRoomName: string) => number | undefined;
+  /**
+   * Creep store and body, used to calculate default terrain costs.
+   */
+  creepMovementInfo?: { usedCapacity: number; body: Creep['body'] };
 }
 
 export * from './CachingStrategies';

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -81,7 +81,7 @@ export interface MoveOpts extends PathFinderOpts {
    */
   routeCallback?: (roomName: string, fromRoomName: string) => number | undefined;
   /**
-   * Creep store and body, used to calculate default terrain costs.
+   * Creep used capacity and body, used to calculate default terrain costs.
    */
   creepMovementInfo?: { usedCapacity: number; body: Creep['body'] };
 }


### PR DESCRIPTION
 - Use body parts and free capacity from creep store to get costs.

Solves #19 