### PR TITLE
bugfix: arguments to String.slice() during path deserialization

### DIFF
--- a/src/lib/CachingStrategies/Serializers/MoveTarget.ts
+++ b/src/lib/CachingStrategies/Serializers/MoveTarget.ts
@@ -35,7 +35,7 @@ export const MoveTargetListSerializer: Serializer<MoveTarget[]> = {
     if (target === undefined) return undefined;
     const targets = [];
     for (let i = 0; i < target.length; i += 3) {
-      const t = MoveTargetSerializer.deserialize(target.slice(i, 3));
+      const t = MoveTargetSerializer.deserialize(target.slice(i, i + 3));
       if (t) targets.push(t);
     }
     return targets;


### PR DESCRIPTION
Fixes a deserialization error
```
TypeError: Cannot read property &#39;charCodeAt&#39; of undefined
    at unpackCoord  (../node_modules/screeps-cartographer/dist/main.js:623:11)
    at unpackPos  (../node_modules/screeps-cartographer/dist/main.js:770:11)
    at Object.deserialize  (../node_modules/screeps-cartographer/dist/main.js:829:17)
    at Object.deserialize  (../node_modules/screeps-cartographer/dist/main.js:849:17)
    at Object.get  (../node_modules/screeps-cartographer/dist/main.js:444:31)
    at moveTo  (../node_modules/screeps-cartographer/dist/main.js:2166:40)
    at CartographerMovement.move  (../src/utils/movement/CartographerMovement.ts:40:3)
```