### PR TITLE
bugfix: check if viable target squares list is not empty

### DIFF
--- a/src/lib/Movement/moveTo.ts
+++ b/src/lib/Movement/moveTo.ts
@@ -177,9 +177,11 @@ export const moveTo = (
   // move to any viable target square, if path is nearly done
   if (path && path[path.length - 2]?.isEqualTo(creep.pos)) {
     // Nearly at end of path
+    let viableSquares = adjacentWalkablePositions(creep.pos, true).filter(p => normalizedTargets.some(t => t.pos.inRangeTo(p, t.range)));
+    if (viableSquares.length === 0) return ERR_NO_PATH;
     move(
       creep,
-      adjacentWalkablePositions(creep.pos, true).filter(p => normalizedTargets.some(t => t.pos.inRangeTo(p, t.range))),
+      viableSquares,
       actualOpts.priority
     );
     return OK;


### PR DESCRIPTION
Fixes error

```
TypeError: Cannot read property &#39;isEqualTo&#39; of undefined
    at move  (../node_modules/screeps-cartographer/dist/main.js:1867:23)
    at moveTo  (../node_modules/screeps-cartographer/dist/main.js:2151:8)
    at moveTo (../src/utils/movement/CartographerMovement.ts:39:11)
```