### PR TITLE
Applying cost matrix to traffic resolution

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "screeps-cartographer",
-  "version": "1.7.5",
+  "version": "1.7.6",
   "description": "An advanced (and open source) movement library for Screeps",
   "homepage": "https://glitchassassin.github.io/screeps-cartographer/",
   "repository": {

--- a/src/lib/Movement/moveTo.ts
+++ b/src/lib/Movement/moveTo.ts
@@ -129,10 +129,10 @@ export const moveTo = (
           creep,
           [
             creep.pos,
-            ...adjacentWalkablePositions(creep.pos, true).filter(p =>
-              normalizedTargets.some(t => t.pos.inRangeTo(p, t.range))
+            ...adjacentWalkablePositions(creep.pos, true).filter(
+              p => normalizedTargets.some(t => t.pos.inRangeTo(p, t.range)) && (!cm || cm.get(p.x, p.y) !== 255) // exclude squares that are blocked by a cost matrix
             )
-          ].filter(p => cm && cm.get(p.x, p.y) !== 255),
+          ],
           actualOpts.priority
         );
         return OK;

--- a/src/lib/Utils/memoize.ts
+++ b/src/lib/Utils/memoize.ts
@@ -1,3 +1,46 @@
+/**
+ * Generic memoizer. Given a function and a way to derive a key from its parameters, cache the
+ * results of the function for each combination of parameters for a given number of ticks.
+ *
+ * Example:
+ * ```
+ * export const getRoomPathDistance = memoize(
+ *   (room1: string, room2: string) => [room1, room2].sort().join(''),
+ *   (room1: string, room2: string) => {
+ *     const newRoute = Game.map.findRoute(room1, room2, {
+ *       routeCallback: room => (getTerritoryIntent(room) === TerritoryIntent.AVOID ? Infinity : 0)
+ *     });
+ *     if (newRoute === -2) return undefined;
+ *     return newRoute.length;
+ *   }
+ * );
+ * ```
+ *
+ * Note that the returned value, if not a primitive, is a reference - so if you mutate the
+ * returned value elsewhere in your code, that change will be reflected next time you call
+ * this function.
+ *
+ * Example:
+ * ```
+ * // resets the set automatically every 10 ticks
+ * export const creepsThatNeedEnergy = memoize(
+ *   (room: string) => room,
+ *   (room: string) => new Set<string>(),
+ *   10
+ * )
+ *
+ * creepsThatNeedEnergy().add(creep.name);
+ *
+ * for (const creepName of creepsThatNeedEnergy()) {
+ *   // get energy to creep
+ * }
+ * ```
+ *
+ * @param indexer Return a unique string as a key for the given combination of `fn`'s parameters
+ * @param fn Generates some value to cache
+ * @param resetAfterTicks Resets all cached values every `n` ticks
+ * @returns The cached return value from `fn`
+ */
 export const memoize = <T extends Array<any>, U>(
   indexer: (...args: T) => string,
   fn: (...args: T) => U,
@@ -18,5 +61,70 @@ export const memoize = <T extends Array<any>, U>(
   };
 };
 
+/**
+ * A shorthand invocation of `memoize` where the results should reset every tick
+ *
+ * Example:
+ * ```
+ * export const buyMarketPrice = memoizeByTick(
+ *   (resourceType: MarketResourceConstant) => resourceType,
+ *   (resourceType: MarketResourceConstant) =>
+ *     Math.min(...Game.market.getAllOrders({ type: ORDER_SELL, resourceType }).map(o => o.price), Infinity)
+ * );
+ * ```
+ */
 export const memoizeByTick = <T extends Array<any>, U>(indexer: (...args: T) => string, fn: (...args: T) => U) =>
   memoize(indexer, fn, 1);
+
+/**
+ * A shorthand invocation of `memoize` where the function has no parameters to generate a key.
+ * Results are generated once and cached for `resetAfterTicks` ticks
+ *
+ * Example:
+ * ```
+ * export const roomData = memoizeOnce(
+ *   () => {
+ *     return Object.keys(Game.rooms)
+ *       .reduce(
+ *         (acc, roomName) => acc[roomName] = {},
+ *         {} as Record<string, any>
+ *       )
+ *   },
+ *   100
+ * )
+ * ```
+ */
+export const memoizeOnce = <T extends Array<any>, U>(fn: (...args: T) => U, resetAfterTicks = Infinity) =>
+  memoize(() => '', fn, resetAfterTicks);
+
+/**
+ * A shorthand invocation of `memoize` where the function has no parameters to generate a key
+ * and should reset each tick. Results are generated once every tick.
+ *
+ * Example:
+ * ```
+ * export const ordersByResourceType = memoizeOncePerTick(() => {
+ *   return Game.market.getAllOrders().reduce(
+ *     (acc, order) => {
+ *       acc[order.resourceType] ??= [];
+ *       acc[order.resourceType].push(order);
+ *     },
+ *     {} as Record<MarketResourceConstant, Order[]>
+ *   )
+ * })
+ * ```
+ */
+export const memoizeOncePerTick = <T extends Array<any>, U>(fn: (...args: T) => U) => memoize(() => '', fn, 1);
+
+/**
+ * Memoizes data in heap when there is no vision in the target room
+ */
+export const memoizeWhenNoVision = <T extends Array<any>, U>(fn: (room: string, ...args: T) => U) => {
+  const cache = new Map<string, U>();
+  return (room: string, ...args: T): U => {
+    if (Game.rooms[room]) {
+      cache.set(room, fn(room, ...args));
+    }
+    return cache.get(room) as U;
+  };
+};

--- a/src/tests/testCases/TestShovingCostMatrix.ts
+++ b/src/tests/testCases/TestShovingCostMatrix.ts
@@ -1,0 +1,80 @@
+import { adjacentWalkablePositions, moveTo } from '../../lib';
+import { TestResult } from '../tests';
+import { CartographerTestCase } from './CartographerTestCase';
+
+export class TestShovingCostMatrix extends CartographerTestCase {
+  _creeps = {
+    c1: '',
+    c2: ''
+  };
+  timeout = 50; // ticks
+  retries = 0;
+  testRegion = {
+    w: 3,
+    h: 3
+  };
+  targetPos1: RoomPosition | undefined;
+  targetPos2: RoomPosition | undefined;
+  blockedSquares: RoomPosition[] | undefined;
+  phase: 'setup' | 'run' = 'setup';
+  running: number | undefined;
+  /**
+   * At the end of a path, we check to see if there are any other viable target squares (besides the final path
+   * square). These need to be filtered based on the roomCallback to make sure we aren't stepping in a blocked square.
+   */
+  test() {
+    if (!this.testRegionOrigin) return TestResult.PENDING;
+    this.targetPos1 ??= new RoomPosition(
+      this.testRegionOrigin.x + 1,
+      this.testRegionOrigin.y + 1,
+      this.testRegionOrigin.roomName
+    );
+    this.blockedSquares ??= adjacentWalkablePositions(this.targetPos1, true).slice(0, -1);
+    this.blockedSquares.forEach(p => Game.rooms[p.roomName].visual.rect(p.x - 0.5, p.y - 0.5, 1, 1, { fill: 'red' }));
+
+    if (this.phase === 'setup') {
+      if (this.creeps.c1.pos.isEqualTo(this.targetPos1)) {
+        this.phase = 'run';
+      }
+      moveTo(
+        this.creeps.c1,
+        { pos: this.targetPos1, range: 0 },
+        {
+          visualizePathStyle: { stroke: '#00ff00' },
+          roomCallback: room => {
+            const cm = new PathFinder.CostMatrix();
+            this.blockedSquares?.filter(pos => pos.roomName === room).forEach(pos => cm.set(pos.x, pos.y, 0xff));
+            return cm;
+          }
+        }
+      );
+      // arrange creeps
+    } else {
+      this.running ??= Game.time;
+      if (this.blockedSquares.some(pos => this.creeps.c1.pos.isEqualTo(pos))) return TestResult.FAIL;
+      if (this.creeps.c2.pos.isEqualTo(this.targetPos1)) return TestResult.PASS;
+      // move, avoiding blocked squares
+      moveTo(
+        this.creeps.c1,
+        { pos: this.targetPos1, range: 1 },
+        {
+          visualizePathStyle: { stroke: '#00ff00' },
+          roomCallback: room => {
+            const cm = new PathFinder.CostMatrix();
+            this.blockedSquares?.filter(pos => pos.roomName === room).forEach(pos => cm.set(pos.x, pos.y, 0xff));
+            return cm;
+          }
+        }
+      );
+      moveTo(
+        this.creeps.c2,
+        { pos: this.targetPos1, range: 0 },
+        {
+          priority: 2,
+          visualizePathStyle: { stroke: '#00ff00' }
+        }
+      );
+    }
+    return TestResult.PENDING;
+  }
+}

--- a/src/tests/testCases/index.ts
+++ b/src/tests/testCases/index.ts
@@ -13,6 +13,7 @@ import { TestPriority } from './TestPriority';
 import { TestPulling } from './TestPulling';
 import { TestRoomEdgeRange } from './TestRoomEdgeRange';
 import { TestShove } from './TestShove';
+import { TestShovingCostMatrix } from './TestShovingCostMatrix';
 import { TestStuck } from './TestStuck';
 import { TestSwarm } from './TestSwarm';
 import { TestTrain } from './TestTrain';
@@ -33,6 +34,7 @@ export const allTestCases = [
   new TestOpportunitySquares(),
   new TestPackPosList(),
   new TestDynamicAvoidance(),
+  new TestShovingCostMatrix()
 ];
 export const testCases = allTestCases.slice();
 const testResults = new Map<CartographerTestCase, TestResult>();


### PR DESCRIPTION
Fixes #44 

If the creep is in range of one of its move targets, instead of following a path, it sets an intent to move to any adjacent square within its move targets (preferring to stay put). This change filters that list to exclude any squares that are marked as impassible on the cost matrix.